### PR TITLE
Fixed a bug where PdfPCell was not calculating height properly.

### DIFF
--- a/src/main/java/com/lowagie/text/pdf/PdfPCell.java
+++ b/src/main/java/com/lowagie/text/pdf/PdfPCell.java
@@ -1005,7 +1005,7 @@ public class PdfPCell extends Rectangle{
 			}
 		}
 		float height = getHeight();
-		if (height < getFixedHeight())
+		if (hasFixedHeight())
 			height = getFixedHeight();
 		else if (height < getMinimumHeight())
 			height = getMinimumHeight();


### PR DESCRIPTION
This solves a bug where Images placed in fixed height table cells would greatly overflow the cell's height. The PdfPCell wasn't properly taking into account its set fixed height when calculating the height of the cell.
